### PR TITLE
Add fallback for unstructured Jamie Oliver recipes

### DIFF
--- a/services/jamie-oliver/properties/recipeInstructions.js
+++ b/services/jamie-oliver/properties/recipeInstructions.js
@@ -1,6 +1,41 @@
 const createQuerySelectorAll = require('utils/createQuerySelectorAll');
+const withFallback = require('utils/withFallback');
+const sanitizeHTML = require('sanitize-html');
 
-module.exports = createQuerySelectorAll(
+// Tested with: https://www.jamieoliver.com/news-and-features/features/make-roast-parsnips/
+const unstructuredRecipe = createQuerySelectorAll(
+  '.entry-content',
+  container => {
+    // Clean up some known noise element.
+    const galleries = container.querySelector('.galleries');
+    if (galleries) {
+      // Remove galleries and all nodes after the galleries.
+      while (galleries.nextSibling) {
+        galleries.nextSibling.parentNode.removeChild(galleries.nextSibling);
+      }
+      galleries.parentNode.removeChild(galleries);
+    }
+
+    const shareBar = container.querySelector('#share-bar-hz');
+    if (shareBar) {
+      shareBar.parentNode.removeChild(shareBar);
+    }
+
+    return sanitizeHTML(
+    	container.innerHTML
+        // Strip <p> tags
+	      .replace(/\<p.*?\>/gi, '')
+    	  // Replace </p> with <br>, will later be converted to \n in cleanup
+        .replace(/\<\/p\>/g, '<br>'),
+      {
+			  // Allow <br> tags, see above
+        allowedTags: ['br']
+		  }
+	  );
+  }
+);
+
+const structuredRecipe = createQuerySelectorAll(
   '.recipeSteps > li',
   instructions => {
     if (
@@ -15,3 +50,5 @@ module.exports = createQuerySelectorAll(
     return instructions.innerHTML;
   }
 );
+
+module.exports = withFallback(unstructuredRecipe)(structuredRecipe);

--- a/utils/withFallback.js
+++ b/utils/withFallback.js
@@ -1,0 +1,8 @@
+/**
+ * Higher-order function, creating a function that will execute its given fallback in case it yields
+ * no results.
+ */
+module.exports = fallbackFn => primaryFn => (...args) => {
+  const result = primaryFn(...args);
+  return result.length ? result : fallbackFn(...args);
+};


### PR DESCRIPTION
Note: misses proper white-space handling.
How would you like to deal with that? Right now I strip all HTML tags from it, ending up with illegible output.
Maybe it would be nice to create some kind of Response object, where `isRawHtml` is a property, so you can differentiate the way you render it in the app. 
That would mean touching every service in the API though, as well as the output rendering.

Well, anyways, this at least ensures the body isn't empty. 🙂